### PR TITLE
Fix sign up logo position on smallest screens

### DIFF
--- a/static/home/css/main.css
+++ b/static/home/css/main.css
@@ -160,7 +160,14 @@ textarea.input-box.input-lg{
 
 }
 
-@media screen and (max-width: 360px) {
+@media screen and (max-width: 375px) {
+
+    #signup {
+        margin-top: 12em;
+    }
+}
+
+@media screen and (max-width: 350px) {
     #logo {
         font-size: 250%;
     }


### PR DESCRIPTION
Sign up heart was too low on the mini screens (iphone SE and Galaxy S8+)
Fixed it here